### PR TITLE
Create TileBitmaskCore lib and update references

### DIFF
--- a/Bitmask.sln
+++ b/Bitmask.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36127.28
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TileBitmaskGen", "TileBitmaskGen\TileBitmaskGen.csproj", "{C1EFB28E-002D-4381-9020-6964944672B9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TileBitmaskCore", "TileBitmaskCore\TileBitmaskCore.csproj", "{88645AFD-4C29-4996-8B49-317572FC7B95}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestProject", "TestProject\TestProject.csproj", "{54450E9C-52E2-4443-86A2-8383CA83268F}"
 EndProject
 Global
@@ -17,6 +19,10 @@ Global
 		{C1EFB28E-002D-4381-9020-6964944672B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C1EFB28E-002D-4381-9020-6964944672B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C1EFB28E-002D-4381-9020-6964944672B9}.Release|Any CPU.Build.0 = Release|Any CPU
+                {88645AFD-4C29-4996-8B49-317572FC7B95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {88645AFD-4C29-4996-8B49-317572FC7B95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {88645AFD-4C29-4996-8B49-317572FC7B95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {88645AFD-4C29-4996-8B49-317572FC7B95}.Release|Any CPU.Build.0 = Release|Any CPU
 		{54450E9C-52E2-4443-86A2-8383CA83268F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{54450E9C-52E2-4443-86A2-8383CA83268F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{54450E9C-52E2-4443-86A2-8383CA83268F}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/TestProject/BitmaskGeneratorTests.cs
+++ b/TestProject/BitmaskGeneratorTests.cs
@@ -1,5 +1,5 @@
 using NUnit.Framework;
-using TileBitmaskGen;
+using TileBitmaskCore;
 using System.Collections.Generic;
 
 namespace TestProject

--- a/TestProject/TestProject.csproj
+++ b/TestProject/TestProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\TileBitmaskGen\TileBitmaskGen.csproj" />
+    <ProjectReference Include="..\TileBitmaskCore\TileBitmaskCore.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TileBitmaskCore/BitmaskGenerator.cs
+++ b/TileBitmaskCore/BitmaskGenerator.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace TileBitmaskGen
+namespace TileBitmaskCore
 {
     public class BitmaskGenerator
     {

--- a/TileBitmaskCore/BitmaskGeneratorJson/BitmaskGeneratorJsonReader.cs
+++ b/TileBitmaskCore/BitmaskGeneratorJson/BitmaskGeneratorJsonReader.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace TileBitmaskGen.BitmaskGeneratorJson
+namespace TileBitmaskCore.BitmaskGeneratorJson
 {
     internal class BitmaskGeneratorJsonReader
     {

--- a/TileBitmaskCore/BitmaskGeneratorJson/BitmaskGeneratorJsonReader.cs
+++ b/TileBitmaskCore/BitmaskGeneratorJson/BitmaskGeneratorJsonReader.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace TileBitmaskCore.BitmaskGeneratorJson
 {
-    internal class BitmaskGeneratorJsonReader
+    public class BitmaskGeneratorJsonReader
     {
         private string _jsonFilePath;
         private List<TileRule> _rules;

--- a/TileBitmaskCore/BitmaskGeneratorJson/BitmaskGeneratorJsonWriter.cs
+++ b/TileBitmaskCore/BitmaskGeneratorJson/BitmaskGeneratorJsonWriter.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace TileBitmaskGen.BitmaskGeneratorJson
+namespace TileBitmaskCore.BitmaskGeneratorJson
 {
     internal class BitmaskGeneratorJsonWriter
     {

--- a/TileBitmaskCore/BitmaskGeneratorJson/BitmaskGeneratorJsonWriter.cs
+++ b/TileBitmaskCore/BitmaskGeneratorJson/BitmaskGeneratorJsonWriter.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace TileBitmaskCore.BitmaskGeneratorJson
 {
-    internal class BitmaskGeneratorJsonWriter
+    public class BitmaskGeneratorJsonWriter
     {
         private string _jsonFilePath;
         private List<TileRule> _rules;

--- a/TileBitmaskCore/TileBitmaskCore.csproj
+++ b/TileBitmaskCore/TileBitmaskCore.csproj
@@ -1,16 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\TileBitmaskCore\TileBitmaskCore.csproj" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/TileBitmaskCore/TileBitmaskStringGenerator.cs
+++ b/TileBitmaskCore/TileBitmaskStringGenerator.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace TileBitmaskGen
+namespace TileBitmaskCore
 {
     internal class TileBitmaskStringGenerator
     {

--- a/TileBitmaskCore/TileBitmaskStringGenerator.cs
+++ b/TileBitmaskCore/TileBitmaskStringGenerator.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace TileBitmaskCore
 {
-    internal class TileBitmaskStringGenerator
+    public class TileBitmaskStringGenerator
     {
 
         private int[] _bitmask;

--- a/TileBitmaskCore/TileRule.cs
+++ b/TileBitmaskCore/TileRule.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace TileBitmaskGen
+namespace TileBitmaskCore
 {
     public class TileRule
     {

--- a/TileBitmaskGen/Form1.cs
+++ b/TileBitmaskGen/Form1.cs
@@ -1,4 +1,5 @@
-using TileBitmaskGen.BitmaskGeneratorJson;
+using TileBitmaskCore.BitmaskGeneratorJson;
+using TileBitmaskCore;
 
 namespace TileBitmaskGen
 {


### PR DESCRIPTION
## Summary
- add `TileBitmaskCore` library project targeting net8.0
- move core generator files into the new project
- update namespaces and using directives
- reference `TileBitmaskCore` from app and tests
- update tests to target `net8.0`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d2a96d974832cbb7635690a5bdad0